### PR TITLE
VS2017 issues

### DIFF
--- a/VsRemovePublishButton/VsRemovePublishButton.csproj
+++ b/VsRemovePublishButton/VsRemovePublishButton.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-<PropertyGroup>
+  <PropertyGroup>
     <MinimumVisualStudioVersion>15.3</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
@@ -86,9 +86,9 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-   <ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
-	<Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/VsRemovePublishButton/VsRemovePublishButtonPackage.cs
+++ b/VsRemovePublishButton/VsRemovePublishButtonPackage.cs
@@ -41,12 +41,13 @@ namespace VsRemovePublishButton {
         }
 
         private async Task DoHidePublishButtonIfRequiredAsync(System.Threading.CancellationToken cancellationToken) {
+            if (ThreadHelper.CheckAccess() == false) {
+                await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            }
+
             OptionPageCustom page = (OptionPageCustom) this.GetDialogPage(typeof(OptionPageCustom));
 
             if (page.HideByDefault) {
-                if (ThreadHelper.CheckAccess() == false) {
-                    await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-                }
 
                 this.DoHidePublishButton();
             }

--- a/VsRemovePublishButton/source.extension.vsixmanifest
+++ b/VsRemovePublishButton/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="VsRemovePublishButton.SebastiaanDammann.d3614f48-4c18-4ab8-abe6-7649e569c118" Version="1.3" Language="en-US" Publisher="Sebastiaan Dammann" />
-        <DisplayName>Remove the Visual Studio Publish button</DisplayName>
-        <Description xml:space="preserve">Removes the Visual Studio "Publish" button from the status bar, which creates a git repository on click.</Description>
-        <MoreInfo>https://github.com/Sebazzz/VsRemovePublishButton</MoreInfo>
-        <Icon>Resources\VsRemovePublishButtonPackage.ico</Icon>
-        <PreviewImage>Resources\Screenshot.png</PreviewImage>
-        <Tags>publish,git</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.9,17.0)" />
-        <InstallationTarget Version="[15.9,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
-        <InstallationTarget Version="[15.9,17.0)" Id="Microsoft.VisualStudio.Pro" />
-    </Installation>
-    <Dependencies>
-    </Dependencies>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.9,17.0)" />
-    </Prerequisites>
+  <Metadata>
+    <Identity Id="VsRemovePublishButton.SebastiaanDammann.d3614f48-4c18-4ab8-abe6-7649e569c118" Version="1.3" Language="en-US" Publisher="Sebastiaan Dammann" />
+    <DisplayName>Remove the Visual Studio Publish button</DisplayName>
+    <Description xml:space="preserve">Removes the Visual Studio "Publish" button from the status bar, which creates a git repository on click.</Description>
+    <MoreInfo>https://github.com/Sebazzz/VsRemovePublishButton</MoreInfo>
+    <Icon>Resources\VsRemovePublishButtonPackage.ico</Icon>
+    <PreviewImage>Resources\Screenshot.png</PreviewImage>
+    <Tags>publish,git</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.27004,17.0)" />
+    <InstallationTarget Version="[15.0.27004,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[15.0.27004,17.0)" Id="Microsoft.VisualStudio.Pro" />
+  </Installation>
+  <Dependencies>
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Fix some VS2017 issues:

- Unable to install on VS 2017 5.9.17
- Unable to initialize extension.  Load fails with the error (from ActivityLog.xml):
```
Due to high risk of deadlock you cannot call GetService from a background thread in an AsyncPackage derived class. You should instead call GetServiceAsync
```