### PR TITLE
Update source.extension.vsixmanifest

### DIFF
--- a/VsRemovePublishButton/source.extension.vsixmanifest
+++ b/VsRemovePublishButton/source.extension.vsixmanifest
@@ -26,6 +26,6 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Change versions to allow installation on VC2022 community and avoid the following failure:

"The extension cannot be installed on this product due to prerequisites that cannot be resolved"